### PR TITLE
fix a bug where config files created by the package were invalid

### DIFF
--- a/CFGpy/_version.py
+++ b/CFGpy/_version.py
@@ -1,3 +1,3 @@
 # This is the single source of truth for CFGpy version. Update only on version release
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/CFGpy/behavioral/Pipeline.py
+++ b/CFGpy/behavioral/Pipeline.py
@@ -23,7 +23,8 @@ class Pipeline:
     def _add_url_to_config(self):
         csv_url = self.downloader.csv_url
         if "&before=" not in csv_url:
-            now_str = datetime.now(timezone.utc).strftime(self.config.SERVER_DATE_FORMAT)
+            date_format_up_to_millisec = self.config.SERVER_DATE_FORMAT.replace("%f", "%3d")
+            now_str = datetime.now(timezone.utc).strftime(date_format_up_to_millisec)
             csv_url += f"&before={now_str}"
 
         self.config.RED_METRICS_CSV_URL = csv_url


### PR DESCRIPTION
when adding a `before` arg to the raw data URL, it will now only have 3 seconds after the decimal, to accommodate RedMetric1