### PR TITLE
Hotfix feature extractor dump

### DIFF
--- a/CFGpy/behavioral/FeatureExtractor.py
+++ b/CFGpy/behavioral/FeatureExtractor.py
@@ -98,7 +98,7 @@ class FeatureExtractor(HasLogger):
             self.input_data.dump(postparsed_path, prettify=True)
 
         if with_exclusions:
-            exclusions_path = f"{name}_exclusions.csv" if name else measures_path.replace(".csv", "") + "_exclusions.csv"
+            exclusions_path = measures_path.replace(".csv", "") + "_exclusions.csv"
             self.exclusions.to_csv(exclusions_path, index=False)
         if with_config:
             self.config.to_yaml(measures_path.replace(".csv", ""))

--- a/CFGpy/behavioral/FeatureExtractor.py
+++ b/CFGpy/behavioral/FeatureExtractor.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pandas as pd
 from datetime import datetime
@@ -84,12 +85,17 @@ class FeatureExtractor(HasLogger):
         self._log_missing_values()
         return self.output_df
 
-    def dump(self, name: str = None, path: str = None, with_config=True, with_exclusions=True):
+    def dump(self, name: str = None, path: str = None, with_config=True, with_exclusions=True, with_filtered_postparsed=True):
         measures_path = resolve_path(name=name, path=path, default_suffix=DEFAULT_FINAL_OUTPUT_FILENAME)
+        # make sure the directory exists
+        measures_dir = os.path.dirname(measures_path)
+        if measures_dir and not os.path.exists(measures_dir):
+            os.makedirs(measures_dir)
 
         self.output_df.to_csv(measures_path, index=False)
-        postparsed_path = resolve_path(name=name, path=path, default_suffix=DEFAULT_POSTPARSED_FILTERED_OUTPUT_FILENAME)
-        self.input_data.dump(postparsed_path, prettify=True)
+        if with_filtered_postparsed:
+            postparsed_path = measures_path.replace(".csv", "") + f"_{DEFAULT_POSTPARSED_FILTERED_OUTPUT_FILENAME}"
+            self.input_data.dump(postparsed_path, prettify=True)
 
         if with_exclusions:
             exclusions_path = f"{name}_exclusions.csv" if name else measures_path.replace(".csv", "") + "_exclusions.csv"

--- a/tests/test_behavioral_pipeline.py
+++ b/tests/test_behavioral_pipeline.py
@@ -10,6 +10,7 @@ import pandas as pd
 import sys
 from enum import Enum
 from typing import Iterable
+import shutil
 
 
 class Process(Enum):
@@ -90,6 +91,37 @@ def test_configurable_parameters_run(cparam: ConfigurableParam):
             pipeline = Pipeline(config=cfg)
             pipeline.run_pipeline()
 
+def test_feature_extractor_dump_correctness():
+    """
+    Test that the feature extractor can dump the extracted features to a csv file and that the dumped file has the same content as the original extracted features.
+    """
+    test_dir = os.path.join(PIPELINE_TEST_FILES_DIR, "set6_iocane")
+    config = Configuration.from_yaml(os.path.join(test_dir, "config.yml"))
+    feature_extractor = FeatureExtractor.from_json(os.path.join(test_dir, TEST_POSTPARSED_FILENAME), config=config)
+    feats = feature_extractor.extract(verbose=True)
+    out_dir = os.path.join(test_dir, "dump_test")
+    feats_dump_name = f"{out_dir}/feats_dump"
+    if os.path.exists(out_dir):
+        shutil.rmtree(out_dir)
+    for with_config in [True, False]:
+        for with_exclusions in [True, False]:
+            for with_filtered_postparsed in [True, False]:
+                feature_extractor.dump(name=feats_dump_name, with_config=with_config,
+                                                         with_exclusions=with_exclusions,
+                                                         with_filtered_postparsed=with_filtered_postparsed)
+                output_suffix_expectations = {
+                    "measures.csv": True,
+                    "measures_config.yml": with_config,
+                    "exclusions.csv": with_exclusions,
+                    "measures_postparsed_clean.json": with_filtered_postparsed
+                }
+
+                for suffix, is_expected in output_suffix_expectations.items():
+                    output_path = f"{feats_dump_name}_{suffix}"
+                    assert os.path.exists(output_path) == is_expected, f"File {output_path} existence does not match expectation based on the dump parameters"
+                    if os.path.exists(output_path):
+                        os.remove(output_path)
+                shutil.rmtree(out_dir)
 
 def test_default_config_dump_compatibility():
     """

--- a/tests/test_behavioral_pipeline.py
+++ b/tests/test_behavioral_pipeline.py
@@ -112,10 +112,21 @@ def test_feature_extractor_dump_correctness():
                 output_suffix_expectations = {
                     "measures.csv": True,
                     "measures_config.yml": with_config,
-                    "exclusions.csv": with_exclusions,
+                    "measures_exclusions.csv": with_exclusions,
                     "measures_postparsed_clean.json": with_filtered_postparsed
                 }
 
+                for suffix, is_expected in output_suffix_expectations.items():
+                    output_path = f"{feats_dump_name}_{suffix}"
+                    assert os.path.exists(output_path) == is_expected, f"File {output_path} existence does not match expectation based on the dump parameters"
+                    if os.path.exists(output_path):
+                        os.remove(output_path)
+
+                # do the same with the path argument
+                measures_path = f"{feats_dump_name}_measures.csv"
+                feature_extractor.dump(path=measures_path, with_config=with_config,
+                                       with_exclusions=with_exclusions,
+                                        with_filtered_postparsed=with_filtered_postparsed)
                 for suffix, is_expected in output_suffix_expectations.items():
                     output_path = f"{feats_dump_name}_{suffix}"
                     assert os.path.exists(output_path) == is_expected, f"File {output_path} existence does not match expectation based on the dump parameters"


### PR DESCRIPTION
There was a bug in the FeatureExtractor dump method - when using the `path` argument instead of the `name` argument, the postpased clean json was dumped to the same path as the measures csv.

In this PR I fixed the bug, added a flag for choosing whether to save the postparsed clean data, and added tests for the correctness of the dumped files for all combinations of `dump` arguments.